### PR TITLE
Fix Elixir 1.5 warning about String.to_char_list/1

### DIFF
--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -37,7 +37,7 @@ defmodule InetCidr do
   a valid ip address.
   """
   def parse_address!(prefix) do
-    {:ok, start_address} = prefix |> String.to_char_list |> :inet.parse_address
+    {:ok, start_address} = prefix |> String.to_charlist |> :inet.parse_address
     start_address
   end
 


### PR DESCRIPTION
Fixes #3 