### PR TITLE
Add list_addresses/1

### DIFF
--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -100,6 +100,18 @@ defmodule InetCidr do
     |> combine_chunks
   end
 
+  def list_addresses({{a,b,c,d,e,f,g,h}, {i,j,k,l,m,n,o,p}, _bits}) do
+    {Range.new(a,i) |> Enum.to_list,
+     Range.new(b,j) |> Enum.to_list,
+     Range.new(c,k) |> Enum.to_list,
+     Range.new(d,l) |> Enum.to_list,
+     Range.new(e,m) |> Enum.to_list,
+     Range.new(f,n) |> Enum.to_list,
+     Range.new(g,o) |> Enum.to_list,
+     Range.new(h,p) |> Enum.to_list}
+    |> combine_chunks
+  end
+
   # internal functions
 
   defp combine_chunks({a_chunks, b_chunks, c_chunks, d_chunks}) do
@@ -108,6 +120,19 @@ defmodule InetCidr do
         c <- c_chunks,
         d <- d_chunks do
 	  {a, b, c, d}
+    end
+  end
+
+  defp combine_chunks({a_chunks, b_chunks, c_chunks, d_chunks, e_chunks, f_chunks, g_chunks, h_chunks}) do
+    for a <- a_chunks,
+        b <- b_chunks,
+        c <- c_chunks,
+        d <- d_chunks,
+        e <- e_chunks,
+        f <- f_chunks,
+        g <- g_chunks,
+        h <- h_chunks do
+	  {a, b, c, d, e, f, g, h}
     end
   end
 

--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -89,7 +89,27 @@ defmodule InetCidr do
   def v6?({a,b,c,d,e,f,g,h}) when a in 0..65535 and b in 0..65535 and c in 0..65535 and d in 0..65535 and e in 0..65535 and f in 0..65535 and g in 0..65535 and h in 0..65535, do: true
   def v6?(_), do: false
 
+  @doc """
+    Returns a list of all IP tuples in the given CIDR range.
+  """
+  def list_addresses({{a,b,c,d}, {e,f,g,h}, _bits}) do
+    {Range.new(a,e) |> Enum.to_list,
+     Range.new(b,f) |> Enum.to_list,
+     Range.new(c,g) |> Enum.to_list,
+     Range.new(d,h) |> Enum.to_list}
+    |> combine_chunks
+  end
+
   # internal functions
+
+  defp combine_chunks({a_chunks, b_chunks, c_chunks, d_chunks}) do
+    for a <- a_chunks,
+        b <- b_chunks,
+        c <- c_chunks,
+        d <- d_chunks do
+	  {a, b, c, d}
+    end
+  end
 
   defp parse_cidr!(cidr_string, adjust) do
     [prefix, prefix_length_str] = String.split(cidr_string, "/", parts: 2)

--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -93,22 +93,12 @@ defmodule InetCidr do
     Returns a list of all IP tuples in the given CIDR range.
   """
   def list_addresses({{a,b,c,d}, {e,f,g,h}, _bits}) do
-    {Range.new(a,e) |> Enum.to_list,
-     Range.new(b,f) |> Enum.to_list,
-     Range.new(c,g) |> Enum.to_list,
-     Range.new(d,h) |> Enum.to_list}
+    {a..e, b..f, c..g, d..h}
     |> combine_chunks
   end
 
   def list_addresses({{a,b,c,d,e,f,g,h}, {i,j,k,l,m,n,o,p}, _bits}) do
-    {Range.new(a,i) |> Enum.to_list,
-     Range.new(b,j) |> Enum.to_list,
-     Range.new(c,k) |> Enum.to_list,
-     Range.new(d,l) |> Enum.to_list,
-     Range.new(e,m) |> Enum.to_list,
-     Range.new(f,n) |> Enum.to_list,
-     Range.new(g,o) |> Enum.to_list,
-     Range.new(h,p) |> Enum.to_list}
+    {a..f, b..j, c..k, d..l, e..m, f..n, g..o, h..p}
     |> combine_chunks
   end
 

--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -105,24 +105,34 @@ defmodule InetCidr do
   # internal functions
 
   defp combine_chunks({a_chunks, b_chunks, c_chunks, d_chunks}) do
-    for a <- a_chunks,
-        b <- b_chunks,
-        c <- c_chunks,
-        d <- d_chunks do
-	  {a, b, c, d}
+    Stream.flat_map a_chunks, fn a ->
+      Stream.flat_map b_chunks, fn b ->
+	Stream.flat_map c_chunks, fn c ->
+	  Stream.flat_map d_chunks, fn d ->
+	    [{a, b, c, d}]
+	  end
+	end
+      end
     end
   end
 
   defp combine_chunks({a_chunks, b_chunks, c_chunks, d_chunks, e_chunks, f_chunks, g_chunks, h_chunks}) do
-    for a <- a_chunks,
-        b <- b_chunks,
-        c <- c_chunks,
-        d <- d_chunks,
-        e <- e_chunks,
-        f <- f_chunks,
-        g <- g_chunks,
-        h <- h_chunks do
-	  {a, b, c, d, e, f, g, h}
+    Stream.flat_map a_chunks, fn a ->
+      Stream.flat_map b_chunks, fn b ->
+	Stream.flat_map c_chunks, fn c ->
+	  Stream.flat_map d_chunks, fn d ->
+	    Stream.flat_map e_chunks, fn e ->
+	      Stream.flat_map f_chunks, fn f ->
+		Stream.flat_map g_chunks, fn g ->
+		  Stream.flat_map h_chunks, fn h ->
+		    [{a, b, c, d, e, f, g, h}]
+		  end
+		end
+	      end
+	    end
+	  end
+	end
+      end
     end
   end
 

--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -93,22 +93,12 @@ defmodule InetCidr do
     Returns a list of all IP tuples in the given CIDR range.
   """
   def list_addresses({{a,b,c,d}, {e,f,g,h}, _bits}) do
-    {Range.new(a,e) |> Enum.to_list,
-     Range.new(b,f) |> Enum.to_list,
-     Range.new(c,g) |> Enum.to_list,
-     Range.new(d,h) |> Enum.to_list}
+    {a..e, b..f, c..g, d..h}
     |> combine_chunks
   end
 
   def list_addresses({{a,b,c,d,e,f,g,h}, {i,j,k,l,m,n,o,p}, _bits}) do
-    {Range.new(a,i) |> Enum.to_list,
-     Range.new(b,j) |> Enum.to_list,
-     Range.new(c,k) |> Enum.to_list,
-     Range.new(d,l) |> Enum.to_list,
-     Range.new(e,m) |> Enum.to_list,
-     Range.new(f,n) |> Enum.to_list,
-     Range.new(g,o) |> Enum.to_list,
-     Range.new(h,p) |> Enum.to_list}
+    {a..i, b..j, c..k, d..l, e..m, f..n, g..o, h..p}
     |> combine_chunks
   end
 

--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -90,7 +90,7 @@ defmodule InetCidr do
   def v6?(_), do: false
 
   @doc """
-    Returns a list of all IP tuples in the given CIDR range.
+    Returns a Stream of all IP tuples in the given CIDR range.
   """
   def list_addresses({{a,b,c,d}, {e,f,g,h}, _bits}) do
     {a..e, b..f, c..g, d..h}

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -102,7 +102,7 @@ defmodule InetCidrTest do
     assert InetCidr.contains?(block, {65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535}) == false
   end
 
-  test "list addresses" do
+  test "list IPv4 addresses" do
     block = {{192, 168, 0, 0}, {192, 168, 0, 7}, 29}
     assert InetCidr.list_addresses(block) == [{192,168,0,0},
 					      {192,168,0,1},
@@ -114,7 +114,7 @@ defmodule InetCidrTest do
 					      {192,168,0,7}]
   end
 
-  test "list lots of addresses" do
+  test "list lots of IPv4 addresses" do
     block = {{10,0,0,0}, {10,63,255,255}, 8}
     addrs = InetCidr.list_addresses(block)
     assert Enum.count(addrs) == InetCidr.address_count({10, 0, 0, 0}, 10)

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -102,4 +102,22 @@ defmodule InetCidrTest do
     assert InetCidr.contains?(block, {65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535}) == false
   end
 
+  test "list addresses" do
+    block = {{192, 168, 0, 0}, {192, 168, 0, 7}, 29}
+    assert InetCidr.list_addresses(block) == [{192,168,0,0},
+					      {192,168,0,1},
+					      {192,168,0,2},
+					      {192,168,0,3},
+					      {192,168,0,4},
+					      {192,168,0,5},
+					      {192,168,0,6},
+					      {192,168,0,7}]
+  end
+
+  test "list lots of addresses" do
+    block = {{10,0,0,0}, {10,63,255,255}, 8}
+    addrs = InetCidr.list_addresses(block)
+    assert Enum.count(addrs) == InetCidr.address_count({10, 0, 0, 0}, 10)
+  end
+
 end

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -115,7 +115,7 @@ defmodule InetCidrTest do
   end
 
   test "list lots of IPv4 addresses" do
-    block = {{10,0,0,0}, {10,63,255,255}, 8}
+    block = {{10, 0, 0, 0}, {10, 63, 255, 255}, 8}
     addrs = InetCidr.list_addresses(block)
     assert Enum.count(addrs) == InetCidr.address_count({10, 0, 0, 0}, 10)
   end

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -115,7 +115,7 @@ defmodule InetCidrTest do
   end
 
   test "list lots of IPv4 addresses" do
-    block = {{10, 0, 0, 0}, {10, 63, 255, 255}, 8}
+    block = {{10, 0, 0, 0}, {10, 63, 255, 255}, 10}
     addrs = InetCidr.list_addresses(block)
     assert Enum.count(addrs) == InetCidr.address_count({10, 0, 0, 0}, 10)
   end

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -120,4 +120,22 @@ defmodule InetCidrTest do
     assert Enum.count(addrs) == InetCidr.address_count({10, 0, 0, 0}, 10)
   end
 
+  test "list IPv6 addresses" do
+    block = {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 0, 0, 0, 0, 0, 7}, 125}
+    assert InetCidr.list_addresses(block) == [{8193,43981,0,0,0,0,0,0},
+                                              {8193,43981,0,0,0,0,0,1},
+                                              {8193,43981,0,0,0,0,0,2},
+                                              {8193,43981,0,0,0,0,0,3},
+                                              {8193,43981,0,0,0,0,0,4},
+                                              {8193,43981,0,0,0,0,0,5},
+                                              {8193,43981,0,0,0,0,0,6},
+                                              {8193,43981,0,0,0,0,0,7}]
+  end
+
+  test "list lots of IPv6 addresses" do
+    block = {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 0, 0, 0, 0, 3, 65535}, 110}
+    addrs = InetCidr.list_addresses(block)
+    assert Enum.count(addrs) == InetCidr.address_count({8193, 43981, 0, 0, 0, 0, 0, 0}, 110)
+  end
+
 end

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -104,37 +104,47 @@ defmodule InetCidrTest do
 
   test "list IPv4 addresses" do
     block = {{192, 168, 0, 0}, {192, 168, 0, 7}, 29}
-    assert InetCidr.list_addresses(block) == [{192,168,0,0},
-					      {192,168,0,1},
-					      {192,168,0,2},
-					      {192,168,0,3},
-					      {192,168,0,4},
-					      {192,168,0,5},
-					      {192,168,0,6},
-					      {192,168,0,7}]
+    addrs =
+      InetCidr.list_addresses(block)
+      |> Enum.to_list
+    assert addrs == [{192,168,0,0},
+		     {192,168,0,1},
+		     {192,168,0,2},
+		     {192,168,0,3},
+		     {192,168,0,4},
+		     {192,168,0,5},
+		     {192,168,0,6},
+		     {192,168,0,7}]
   end
 
   test "list lots of IPv4 addresses" do
     block = {{10, 0, 0, 0}, {10, 63, 255, 255}, 10}
-    addrs = InetCidr.list_addresses(block)
+    addrs =
+      InetCidr.list_addresses(block)
+      |> Enum.to_list
     assert Enum.count(addrs) == InetCidr.address_count({10, 0, 0, 0}, 10)
   end
 
   test "list IPv6 addresses" do
     block = {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 0, 0, 0, 0, 0, 7}, 125}
-    assert InetCidr.list_addresses(block) == [{8193,43981,0,0,0,0,0,0},
-                                              {8193,43981,0,0,0,0,0,1},
-                                              {8193,43981,0,0,0,0,0,2},
-                                              {8193,43981,0,0,0,0,0,3},
-                                              {8193,43981,0,0,0,0,0,4},
-                                              {8193,43981,0,0,0,0,0,5},
-                                              {8193,43981,0,0,0,0,0,6},
-                                              {8193,43981,0,0,0,0,0,7}]
+    addrs =
+      InetCidr.list_addresses(block)
+      |> Enum.to_list
+    assert addrs == [{8193,43981,0,0,0,0,0,0},
+                     {8193,43981,0,0,0,0,0,1},
+                     {8193,43981,0,0,0,0,0,2},
+                     {8193,43981,0,0,0,0,0,3},
+                     {8193,43981,0,0,0,0,0,4},
+                     {8193,43981,0,0,0,0,0,5},
+                     {8193,43981,0,0,0,0,0,6},
+                     {8193,43981,0,0,0,0,0,7}]
   end
 
   test "list lots of IPv6 addresses" do
     block = {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 0, 0, 0, 0, 3, 65535}, 110}
-    addrs = InetCidr.list_addresses(block)
+    addrs =
+      InetCidr.list_addresses(block)
+      |> Enum.to_list
     assert Enum.count(addrs) == InetCidr.address_count({8193, 43981, 0, 0, 0, 0, 0, 0}, 110)
   end
 


### PR DESCRIPTION
This function lists all the addresses in a CIDR range, for both IPv4 and IPv6.