### PR TITLE
Fix typesystem warnings

### DIFF
--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -28,12 +28,12 @@ defmodule InetCidr do
   @doc since: "1.0.6"
   @doc """
   Parses a string containing either an IPv4 or IPv6 CIDR block using the
-  notation like `192.168.0.0/16` or `2001:abcd::/32`. 
+  notation like `192.168.0.0/16` or `2001:abcd::/32`.
 
   You can optionally pass true as the second argument to adjust the start `IP`
   address if it is not consistent with the cidr length.
   For example, `192.168.0.0/0` would be adjusted to have a start IP of `0.0.0.0`
-  instead of `192.168.0.0`. 
+  instead of `192.168.0.0`.
 
   It returns an `{:ok, {start address, end address, cidr length}}` tuple if the string contains a valid IP address.
 
@@ -43,12 +43,7 @@ defmodule InetCidr do
     try do
       {:ok, parse_cidr!(cidr_string, adjust)}
     rescue
-      e ->
-        # do NOT double wrap error tuples
-        case e do
-          {:error, err} -> {:error, err}
-          err -> {:error, err}
-        end
+      err -> {:error, err}
     end
   end
 
@@ -71,7 +66,7 @@ defmodule InetCidr do
   @doc since: "1.0.6"
   @doc """
   Convenience function that takes an IPv4 or IPv6 address as a string and
-  returns the address.  
+  returns the address.
 
   It returns an `{:ok, address}` tuple if the string contains a valid IP address.
 
@@ -82,12 +77,7 @@ defmodule InetCidr do
     try do
       {:ok, parse_address!(prefix)}
     rescue
-      e ->
-        # do NOT double wrap error tuples
-        case e do
-          {:error, err} -> {:error, err}
-          err -> {:error, err}
-        end
+      err -> {:error, err}
     end
   end
 
@@ -198,12 +188,7 @@ defmodule InetCidr do
     try do
       {:ok, calc_end_address!(start_address, prefix_length)}
     rescue
-      e ->
-        # do NOT double wrap error tuples
-        case e do
-          {:error, err} -> {:error, err}
-          err -> {:error, err}
-        end
+      err -> {:error, err}
     end
   end
 


### PR DESCRIPTION
rescue block clauses can only match on Exception.

Fixes warnings on elixir 1.18-dev
```
    warning: the following clause will never match:

        {:error, err}

    because it attempts to match on the result of:

        e

    which has type:

        %{..., __exception__: true, __struct__: atom()}

    typing violation found at:
    │
 49 │           {:error, err} -> {:error, err}
    │           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/inet_cidr.ex:49: InetCidr.parse_cidr/2
```