### PR TITLE
Add `InetCidr.disjoint?/2`

### DIFF
--- a/Cheatsheet.cheatmd
+++ b/Cheatsheet.cheatmd
@@ -50,3 +50,23 @@ iex> address1 = InetCidr.parse_address!("192.168.15.20")
 iex> InetCidr.contains?(cidr, address1)
 true
 ```
+
+## Check if two CIDR blocks are disjoint
+
+This works for IPv4 and IPv6 CIDR blocks.
+
+```elixir
+iex> cidr1 = InetCidr.parse_cidr!("192.168.0.0/24")
+{{192,168,0,0}, {192,168,0,255}, 24}
+
+iex> cidr2 = InetCidr.parse_cidr!("192.168.1.0/24")
+{{192,168,1,0}, {192,168,1,255}, 24}
+
+iex> InetCidr.disjoint?(cidr1, cidr2)
+true
+
+iex> cidr3 = InetCidr.parse_cidr!("192.168.0.0/16")
+{{192,168,0,0}, {192,168,255,255}, 16}
+
+iex> InetCidr.disjoint?(cidr1, cidr3)
+false

--- a/lib/inet_cidr.ex
+++ b/lib/inet_cidr.ex
@@ -28,12 +28,12 @@ defmodule InetCidr do
   @doc since: "1.0.6"
   @doc """
   Parses a string containing either an IPv4 or IPv6 CIDR block using the
-  notation like `192.168.0.0/16` or `2001:abcd::/32`. 
+  notation like `192.168.0.0/16` or `2001:abcd::/32`.
 
   You can optionally pass true as the second argument to adjust the start `IP`
   address if it is not consistent with the cidr length.
   For example, `192.168.0.0/0` would be adjusted to have a start IP of `0.0.0.0`
-  instead of `192.168.0.0`. 
+  instead of `192.168.0.0`.
 
   It returns an `{:ok, {start address, end address, cidr length}}` tuple if the string contains a valid IP address.
 
@@ -69,7 +69,7 @@ defmodule InetCidr do
   @doc since: "1.0.6"
   @doc """
   Convenience function that takes an IPv4 or IPv6 address as a string and
-  returns the address.  
+  returns the address.
 
   It returns an `{:ok, address}` tuple if the string contains a valid IP address.
 
@@ -162,6 +162,15 @@ defmodule InetCidr do
       do: true
 
   def v6?(_), do: false
+
+  @doc """
+  Returns true if CIDR1 and CIDR2 have no addresses in common (no overlap).
+  """
+  def disjoint?(
+        {start_address1, _end_address1, _len1} = cidr1,
+        {start_address2, _end_address2, _len2} = cidr2
+      ),
+      do: not contains?(cidr1, start_address2) and not contains?(cidr2, start_address1)
 
   # internal functions
 

--- a/test/inet_cidr_test.exs
+++ b/test/inet_cidr_test.exs
@@ -200,4 +200,67 @@ defmodule InetCidrTest do
       end
     )
   end
+
+  test "disjoint? with non-overlapping ipv4 blocks" do
+    block1 = {{192, 168, 0, 0}, {192, 168, 0, 255}, 24}
+    block2 = {{192, 168, 1, 0}, {192, 168, 1, 255}, 24}
+    assert InetCidr.disjoint?(block1, block2) == true
+    assert InetCidr.disjoint?(block2, block1) == true
+  end
+
+  test "disjoint? with overlapping ipv4 blocks" do
+    block1 = {{192, 168, 0, 0}, {192, 168, 255, 255}, 16}
+    block2 = {{192, 168, 1, 0}, {192, 168, 1, 255}, 24}
+    assert InetCidr.disjoint?(block1, block2) == false
+    assert InetCidr.disjoint?(block2, block1) == false
+  end
+
+  test "disjoint? with identical ipv4 blocks" do
+    block = {{10, 0, 0, 0}, {10, 0, 0, 255}, 24}
+    assert InetCidr.disjoint?(block, block) == false
+  end
+
+  test "disjoint? with adjacent ipv4 blocks" do
+    block1 = {{10, 0, 0, 0}, {10, 0, 0, 127}, 25}
+    block2 = {{10, 0, 0, 128}, {10, 0, 0, 255}, 25}
+    assert InetCidr.disjoint?(block1, block2) == true
+    assert InetCidr.disjoint?(block2, block1) == true
+  end
+
+  test "disjoint? with non-overlapping ipv6 blocks" do
+    block1 =
+      {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 65535, 65535, 65535, 65535, 65535, 65535},
+       32}
+
+    block2 =
+      {{8193, 43982, 0, 0, 0, 0, 0, 0}, {8193, 43982, 65535, 65535, 65535, 65535, 65535, 65535},
+       32}
+
+    assert InetCidr.disjoint?(block1, block2) == true
+    assert InetCidr.disjoint?(block2, block1) == true
+  end
+
+  test "disjoint? with overlapping ipv6 blocks" do
+    block1 =
+      {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 65535, 65535, 65535, 65535, 65535, 65535},
+       32}
+
+    block2 =
+      {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 8191, 65535, 65535, 65535, 65535, 65535},
+       35}
+
+    assert InetCidr.disjoint?(block1, block2) == false
+    assert InetCidr.disjoint?(block2, block1) == false
+  end
+
+  test "disjoint? with ipv4 and ipv6 blocks returns true" do
+    block_v4 = {{192, 168, 0, 0}, {192, 168, 255, 255}, 16}
+
+    block_v6 =
+      {{8193, 43981, 0, 0, 0, 0, 0, 0}, {8193, 43981, 65535, 65535, 65535, 65535, 65535, 65535},
+       32}
+
+    assert InetCidr.disjoint?(block_v4, block_v6) == true
+    assert InetCidr.disjoint?(block_v6, block_v4) == true
+  end
 end


### PR DESCRIPTION
This changes add a new function `InetCidr.disjoint?/2` to check when two CIDRs don't have overlaping addresses.

### Cheatsheet:

#### Check if two CIDR blocks are disjoint

This works for IPv4 and IPv6 CIDR blocks.

```elixir
iex> cidr1 = InetCidr.parse_cidr!("192.168.0.0/24")
{{192,168,0,0}, {192,168,0,255}, 24}

iex> cidr2 = InetCidr.parse_cidr!("192.168.1.0/24")
{{192,168,1,0}, {192,168,1,255}, 24}

iex> InetCidr.disjoint?(cidr1, cidr2)
true

iex> cidr3 = InetCidr.parse_cidr!("192.168.0.0/16")
{{192,168,0,0}, {192,168,255,255}, 16}

iex> InetCidr.disjoint?(cidr1, cidr3)
false